### PR TITLE
add getDescription() method for class DisplayQualityGateStatus

### DIFF
--- a/src/main/java/org/sonarsource/plugins/example/hooks/DisplayQualityGateStatus.java
+++ b/src/main/java/org/sonarsource/plugins/example/hooks/DisplayQualityGateStatus.java
@@ -29,6 +29,11 @@ import org.sonar.api.utils.log.Loggers;
  * A real use-case would be to send an email or to notify an IRC channel.
  */
 public class DisplayQualityGateStatus implements PostProjectAnalysisTask {
+
+  public String getDescription() {
+    return "DisplayQualityGateStatus";
+  }
+
   @Override
   public void finished(ProjectAnalysis analysis) {
     QualityGate gate = analysis.getQualityGate();


### PR DESCRIPTION
the interface PostProjectAnalysisTask of sonar-plugin-api:8.0  have added a abstract method: getDescription()
`String getDescription();`
which will result in exception when the sonarqube version is 8.0, the exception as follows:
```
java.lang.AbstractMethodError: Receiver class org.sonarsource.plugins.example.hooks.DisplayQualityGateStatus does not define or inherit an implementation of the resolved method 'abstract java.lang.String getDescription()' of interface org.sonar.api.ce.posttask.PostProjectAnalysisTask
```
so add the getDescription() method to keep compatibility.