### PR TITLE
Add support for SonarQube 8.3.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sonar.apiVersion>7.9</sonar.apiVersion>
+    <sonar.apiVersion>8.3.1.34397</sonar.apiVersion>
     <jdk.min.version>1.8</jdk.min.version>
     <sonar.sources>src/main/java,src/main/js</sonar.sources>
   </properties>

--- a/src/main/java/org/sonarsource/plugins/example/hooks/DisplayQualityGateStatus.java
+++ b/src/main/java/org/sonarsource/plugins/example/hooks/DisplayQualityGateStatus.java
@@ -36,4 +36,9 @@ public class DisplayQualityGateStatus implements PostProjectAnalysisTask {
       Loggers.get(getClass()).info("Quality gate is " + gate.getStatus());
     }
   }
+
+  @Override
+  public String getDescription() {
+    return "Display Quality Gate status";
+  }
 }


### PR DESCRIPTION
The `DisplayQualityGateStatus` class was not overriding `getDescription()`, preventing the task to execute and logging an error