### PR TITLE
Remove duplicate property.

### DIFF
--- a/src/main/java/org/sonarsource/plugins/example/ExamplePlugin.java
+++ b/src/main/java/org/sonarsource/plugins/example/ExamplePlugin.java
@@ -53,7 +53,7 @@ public class ExamplePlugin implements Plugin {
 
     // tutorial on languages
     context.addExtensions(FooLanguage.class, FooQualityProfile.class);
-    context.addExtension(FooLanguageProperties.getProperties());
+    context.addExtensions(FooLanguageProperties.getProperties());
 
     // tutorial on measures
     context
@@ -70,13 +70,5 @@ public class ExamplePlugin implements Plugin {
 
     // tutorial on web extensions
     context.addExtension(MyPluginPageDefinition.class);
-
-    context.addExtensions(asList(
-      PropertyDefinition.builder("sonar.foo.file.suffixes")
-        .name("Suffixes FooLint")
-        .description("Suffixes supported by FooLint")
-        .category("FooLint")
-        .defaultValue("")
-        .build()));
   }
 }

--- a/src/main/java/org/sonarsource/plugins/example/settings/FooLanguageProperties.java
+++ b/src/main/java/org/sonarsource/plugins/example/settings/FooLanguageProperties.java
@@ -40,7 +40,7 @@ public class FooLanguageProperties {
       .defaultValue(FILE_SUFFIXES_DEFAULT_VALUE)
       .category("Foo")
       .name("File Suffixes")
-      .description("Comma-separated list of suffixes for files to analyze.")
+      .description("List of suffixes for files to analyze.")
       .onQualifiers(Qualifiers.PROJECT)
       .build());
   }


### PR DESCRIPTION
Two definitions of the `sonar.foo.file.suffixes` property were present in the project. 

Only one was used, by accident because the other was added by using addExtension instead of addExtensions.

I removed one of them because anyway SQ won't start if we have duplicate keys