### PR TITLE
SONAR-16610 added example of using new education features in rule definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,14 +12,15 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sonar.apiVersion>9.4.0.54424</sonar.apiVersion>
+    <sonar.apiVersion>9.8.0.203</sonar.apiVersion>
+    <sonar.testingHarnessVersion>9.5.0.56709</sonar.testingHarnessVersion>
     <jdk.min.version>11</jdk.min.version>
     <sonar.sources>src/main/java,src/main/js</sonar.sources>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
+      <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar.apiVersion}</version>
       <scope>provided</scope>
@@ -36,7 +37,7 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-testing-harness</artifactId>
-      <version>${sonar.apiVersion}</version>
+      <version>${sonar.testingHarnessVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -57,6 +58,7 @@
         <configuration>
           <pluginKey>example</pluginKey>
           <pluginClass>org.sonarsource.plugins.example.ExamplePlugin</pluginClass>
+          <sonarQubeMinVersion>9.5</sonarQubeMinVersion>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/org/sonarsource/plugins/example/rules/JavaRulesDefinition.java
+++ b/src/main/java/org/sonarsource/plugins/example/rules/JavaRulesDefinition.java
@@ -22,7 +22,12 @@ package org.sonarsource.plugins.example.rules;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rule.RuleStatus;
 import org.sonar.api.rule.Severity;
+import org.sonar.api.server.rule.RuleDescriptionSection;
 import org.sonar.api.server.rule.RulesDefinition;
+
+import static org.sonar.api.server.rule.RuleDescriptionSection.RuleDescriptionSectionKeys.HOW_TO_FIX_SECTION_KEY;
+import static org.sonar.api.server.rule.RuleDescriptionSection.RuleDescriptionSectionKeys.INTRODUCTION_SECTION_KEY;
+import static org.sonar.api.server.rule.RuleDescriptionSection.RuleDescriptionSectionKeys.ROOT_CAUSE_SECTION_KEY;
 
 public class JavaRulesDefinition implements RulesDefinition {
 
@@ -34,10 +39,18 @@ public class JavaRulesDefinition implements RulesDefinition {
   public void define(Context context) {
     NewRepository repository = context.createRepository(REPOSITORY, JAVA_LANGUAGE).setName("My Custom Java Analyzer");
 
+    var hibernate = new org.sonar.api.server.rule.Context("hibernate", "Hibernate");
+    var myBatis = new org.sonar.api.server.rule.Context("mybatis", "MyBatis");
+
     NewRule x1Rule = repository.createRule(RULE_ON_LINE_1.rule())
       .setName("Stupid rule")
       .setHtmlDescription("Generates an issue on every line 1 of Java files")
-
+      .addDescriptionSection(descriptionSection(INTRODUCTION_SECTION_KEY, "This rule is not that stupid", null))
+      .addDescriptionSection(descriptionSection(ROOT_CAUSE_SECTION_KEY, "The root cause of this issue is this and that.", null))
+      .addDescriptionSection(descriptionSection(HOW_TO_FIX_SECTION_KEY,
+        "To fix an issue reported by this rule when using Hibernate do this and that.", hibernate))
+      .addDescriptionSection(descriptionSection(HOW_TO_FIX_SECTION_KEY,
+        "To fix an issue reported by this rule when using MyBatis do this and that.", myBatis))
       // optional tags
       .setTags("style", "stupid")
 
@@ -51,5 +64,14 @@ public class JavaRulesDefinition implements RulesDefinition {
 
     // don't forget to call done() to finalize the definition
     repository.done();
+  }
+
+  private static RuleDescriptionSection descriptionSection(String sectionKey, String htmlContent, org.sonar.api.server.rule.Context context) {
+    return RuleDescriptionSection.builder()
+      .sectionKey(sectionKey)
+      .htmlContent(htmlContent)
+      //Optional context - can be any framework or component for which you want to create detailed description
+      .context(context)
+      .build();
   }
 }


### PR DESCRIPTION
SONAR-16610

I decided to not include generic concepts as Community users will not be able to add content for each generic concept (although I am happy to add if it is needed).

Tested with SonarQube from master branch.
![image](https://user-images.githubusercontent.com/77498856/179707555-01f333d7-0dc9-49a9-a47c-13aa23f9ddc1.png)

I am going to update sonar-packaging-maven-plugin in a seperate PR, but it is not strictly required to merge this as we can make use of `sonarQubeMinVersion` property.