### PR TITLE
SC-35440 scripted update of SonarSource SA to SonarSource Sàrl

### DIFF
--- a/conf/env.js
+++ b/conf/env.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/conf/jest/CSSStub.js
+++ b/conf/jest/CSSStub.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/conf/jest/FileStub.js
+++ b/conf/jest/FileStub.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/conf/jest/SetupTestEnvironment.js
+++ b/conf/jest/SetupTestEnvironment.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/conf/webpack/webpack.config.dev.js
+++ b/conf/webpack/webpack.config.dev.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/conf/webpack/webpack.config.js
+++ b/conf/webpack/webpack.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/conf/webpack/webpack.config.prod.js
+++ b/conf/webpack/webpack.config.prod.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/ExamplePlugin.java
+++ b/src/main/java/org/sonarsource/plugins/example/ExamplePlugin.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/hooks/DisplayQualityGateStatus.java
+++ b/src/main/java/org/sonarsource/plugins/example/hooks/DisplayQualityGateStatus.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/hooks/PostJobInScanner.java
+++ b/src/main/java/org/sonarsource/plugins/example/hooks/PostJobInScanner.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/languages/FooLanguage.java
+++ b/src/main/java/org/sonarsource/plugins/example/languages/FooLanguage.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/languages/FooQualityProfile.java
+++ b/src/main/java/org/sonarsource/plugins/example/languages/FooQualityProfile.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/measures/ComputeSizeAverage.java
+++ b/src/main/java/org/sonarsource/plugins/example/measures/ComputeSizeAverage.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/measures/ComputeSizeRating.java
+++ b/src/main/java/org/sonarsource/plugins/example/measures/ComputeSizeRating.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/measures/ExampleMetrics.java
+++ b/src/main/java/org/sonarsource/plugins/example/measures/ExampleMetrics.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/measures/SetSizeOnFilesSensor.java
+++ b/src/main/java/org/sonarsource/plugins/example/measures/SetSizeOnFilesSensor.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/rules/CreateIssuesOnJavaFilesSensor.java
+++ b/src/main/java/org/sonarsource/plugins/example/rules/CreateIssuesOnJavaFilesSensor.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/rules/FlagRuleDefinition.java
+++ b/src/main/java/org/sonarsource/plugins/example/rules/FlagRuleDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/rules/FooLintIssuesLoaderSensor.java
+++ b/src/main/java/org/sonarsource/plugins/example/rules/FooLintIssuesLoaderSensor.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/rules/JavaRulesDefinition.java
+++ b/src/main/java/org/sonarsource/plugins/example/rules/JavaRulesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/settings/FooLanguageProperties.java
+++ b/src/main/java/org/sonarsource/plugins/example/settings/FooLanguageProperties.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/settings/HelloWorldProperties.java
+++ b/src/main/java/org/sonarsource/plugins/example/settings/HelloWorldProperties.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/settings/SayHelloFromScanner.java
+++ b/src/main/java/org/sonarsource/plugins/example/settings/SayHelloFromScanner.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/plugins/example/web/MyPluginPageDefinition.java
+++ b/src/main/java/org/sonarsource/plugins/example/web/MyPluginPageDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/admin_page/components/InstanceStatisticsApp.js
+++ b/src/main/js/admin_page/components/InstanceStatisticsApp.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/admin_page/index.js
+++ b/src/main/js/admin_page/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/common/api.js
+++ b/src/main/js/common/api.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/global_page/app.css
+++ b/src/main/js/global_page/app.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/global_page/app.js
+++ b/src/main/js/global_page/app.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/global_page/index.js
+++ b/src/main/js/global_page/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/portfolio_page/components/MeasuresHistory.js
+++ b/src/main/js/portfolio_page/components/MeasuresHistory.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/portfolio_page/components/VersionsMeasuresHistoryApp.js
+++ b/src/main/js/portfolio_page/components/VersionsMeasuresHistoryApp.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/portfolio_page/index.js
+++ b/src/main/js/portfolio_page/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/project_page/index.js
+++ b/src/main/js/project_page/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/project_page/view/AppView.js
+++ b/src/main/js/project_page/view/AppView.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/js/style.css
+++ b/src/main/js/style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
Automated update of license headers to change 'SonarSource SA' to 'SonarSource Sàrl' across all text files.

This change was made using the auto_license_replacement.py.py script.