### PR TITLE
SC-41038 Fix the Analysis Processing team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/orchestration-processing-squad
+.github/CODEOWNERS @sonarsource/quality-processing-squad


### PR DESCRIPTION
## Summary
- Update CODEOWNERS file to reflect GitHub team name change from `orchestration-processing-squad` to `quality-processing-squad`

## Context
The Github team orchestration-processing-squad has been renamed to [quality-processing-squad](https://github.com/orgs/SonarSource/teams/quality-processing-squad) due to the move from the Code Orchestration team to Code Quality.

Fixes: SC-41026

🤖 Generated with [Claude Code](https://claude.com/claude-code)