### PR TITLE
Change Code Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-.github/CODEOWNERS @sonarsource/quality-processing-squad
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @sonarsource/code-quality-ci-experience-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Code Owners:**
  - Updated `.github/CODEOWNERS` to assign the repository to `@sonarsource/code-quality-ci-experience-squad`.

<sub>This will update automatically on new commits.</sub>